### PR TITLE
Update info on apt and nodejs installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For the full and official documentation, see [here](https://github.com/nodesourc
 ### Node 10.x
 ```
 # For ubuntu
-curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 Note that `-y` allows us to say yes in the "confirmation" prompt that appears whenever we try to install a program using `apt`.
@@ -59,9 +59,9 @@ Note that `-y` allows us to say yes in the "confirmation" prompt that appears wh
 >
 > For this reason, it's best to download the script first, inspect it line-by-line to make sure it isn't upto any funny buisness, the run it.
 >
->    curl -sL https://deb.nodesource.com/setup_10.x -o setup_10.x.sh
->    less setup_10.x.sh   # take a look at the file
->    sudo -E bash setup_10.x.sh  # Now we can run the script
+>     curl -sL https://deb.nodesource.com/setup_10.x -o setup_10.x.sh
+>     less setup_10.x.sh   # take a look at the file
+>     sudo -E bash setup_10.x.sh  # Now we can run the script
 
 #### Personal Experience
 I initially ran `sudo apt install nodejs`, but this gave me node version 8.x.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a repository containing personal notes, which will be based on my own ex
 
 ## Personal Setup
 - Windows 10 Home (1903)
-- WSL 1.0 - Ubuntu 18.04.2 LTS
+- WSL 1.0 - Ubuntu 18.04.2 LTS “[Bionic Beaver](http://releases.ubuntu.com/18.04/)”
 
 For the time being, I will not be using [PPAs](#PPAs) to install software.
 
@@ -38,20 +38,42 @@ Personal package archives, essentially, are packages reserved for _non-standard_
 > Some developers automatically add an entry to the sources.list and then it is updated like a regular software. Google Chrome is one such example.
 
 ## Installing `nodejs`
-NodeJS can be installed multiple ways, including via package managers like npm (although what version of node you get upon installation depends on the package manager you are using). This method assumes we are installing NodeJS via `apt` only.
+
+NodeJS can be installed multiple ways, including via package managers (although what version of node you get upon installation depends on the package manager you are using and its package index). This method assumes we are installing NodeJS via `apt` only.
 
 For the full and official documentation, see [here](https://github.com/nodesource/distributions/blob/master/README.md). 
 
 ### Node 10.x
 ```
 # For ubuntu
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
 sudo apt-get install -y nodejs
 ```
 Note that `-y` allows us to say yes in the "confirmation" prompt that appears whenever we try to install a program using `apt`.
 
+> ⚠️ **Danger** ⚠️: installing software via `curl -sL https://example.com/some-script.sh | sudo -E bash -` means you're
+> allowing an external script (e.g., <https://deb.nodesource.com/setup_10.x>) to run on your computer with `sudo`, which
+> usually means, it has **full control** over your system and its data. **Only do this if you 100% trust the source of the script** and if you can **verify its authenticity**.
+>
+> A malicious user could literally write `rm -rf --no-preserve-root /` and wipe your computer this way! 😵💀
+>
+> For this reason, it's best to download the script first, inspect it line-by-line to make sure it isn't upto any funny buisness, the run it.
+>
+>    curl -sL https://deb.nodesource.com/setup_10.x -o setup_10.x.sh
+>    less setup_10.x.sh   # take a look at the file
+>    sudo -E bash setup_10.x.sh  # Now we can run the script
+
 #### Personal Experience
-I initially ran `sudo apt install nodejs`, but this gave me node version 8.x. To update to a newer version, I had to use [nvm](#installing-nvm). To use `nvm` however, I also had to install [npm](#installing-npm).
+I initially ran `sudo apt install nodejs`, but this gave me node version 8.x.
+
+The reason it installs ~8.x is because...
+
+ 1. apt consults its package index
+ 2. the package index finds the package `nodejs` in the `Universe` respository.
+ 3. The `Universe` repository **locks versions** for each Ubuntu release. This is so that if you install say Ubuntu 18.04 LTS on many different , you get a consistent set of packages, and have a lower likelihood of things breaking due to updates.
+ 4. [The version of NodeJS locked for Ubuntu 18.04 is NodeJS 8.x](https://packages.ubuntu.com/bionic/nodejs)
+
+To update to a newer version, I had to use [nvm](#installing-nvm). To use `nvm` however, I also had to install [npm](#installing-npm). (Ed: that's so weird... `nvm` is a series of Bash scripts; it should _not_ require npm at all! 🤔🤔🤔)
 
 ## Installing `npm`
 ### Using no PPAs
@@ -59,7 +81,9 @@ I installed `npm` using the following commands:
 1. `sudo apt install npm`
 2. `sudo npm install npm@latest -g`
 
-For some reason, I did not get the latest version of npm. I had to run the second command to upgrade to the latest version.
+I did not get the latest version of npm—the version locked for [Ubuntu Bionic is 3.5.2](https://packages.ubuntu.com/bionic/npm). I had to run the second command to upgrade to the latest version.
+
+`npm` runs _in_ `nodejs`. Hence, a required package to install `npm` is `nodejs`. You can see all of `npm`'s dependent packages on the Ubunutu 18.04 Bionic's package page for `npm`: <https://packages.ubuntu.com/bionic/npm#pdeps>
 
 ### Using PPAs
 There are several good resource explaining the steps for installing npm using PPAs, like [this](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-18-04) and [this](https://tecadmin.net/install-latest-nodejs-npm-on-ubuntu/).


### PR DESCRIPTION
@kpatenio!

As promised, here are some suggestions/corrections.

I answered _why_ it installs NodeJS 8.x, which seems pretty out of date now. It's because Ubuntu **locks** packages at certain versions for each release of Ubuntu, e.g., Ubuntu 18.04.

Speaking of Ubuntu 18.04, instead of using version numbers, a lot of people use the nickname of Ubuntu releases. The nickname of Ubuntu 18.04 is Bionic Beaver. But then people are lazy, and just call it "bionic". This has implications if you want to figure out which version is locked for your version of Ubuntu, as the package description requires both the short name of the release, and the name of the package. e.g.,

> `https://packages.ubuntu.com/<ubuntu-release>/<package>`

e.g.,

  - What version of Python am I installing on Ubuntu 18.04 “**Bionic** Beaver”? <https://packages.ubuntu.com/bionic/python3>?
 - How about on Ubuntu 19.04 “**Disco** Dingo”? <https://packages.ubuntu.com/disco/python3>
 - What version of ffmpeg is installed on Ubuntu 16.04 ”**Xenial** Xerus”? <https://packages.ubuntu.com/xenial/ffmpeg>

Also, installing packages by piping `curl` into `sudo bash` is a Bad Thing™, but people do it anyway. Just be safe, and verify that the script isn't deleting your whole hard drive, or installing a hidden BitCoin miner or something 🙃

I hope this helps! If things are confusing, or you want to edit anything, feel free to reach out! 😄